### PR TITLE
Fixed generated HTML for edge case chunk.

### DIFF
--- a/lib/pretty_diff/diff.rb
+++ b/lib/pretty_diff/diff.rb
@@ -11,7 +11,7 @@
 #
 module PrettyDiff
   class Diff
-    CHUNK_REGEXP = /^@@ .+ @@\n?$?/
+    CHUNK_REGEXP = /^@@ .+? @@.*\n?$/
 
     attr_reader :unified_diff, :generator, :out_encoding
 
@@ -61,10 +61,9 @@ module PrettyDiff
     def find_chunks
       chunks_meta = contents.scan(CHUNK_REGEXP)
       [].tap do |chunks|
-        split = contents.split(CHUNK_REGEXP)
-        split.shift
-        split.each_with_index do |lines, idx|
-          chunks << Chunk.new(self, chunks_meta[idx], lines)
+        split = contents.split(CHUNK_REGEXP)[1..-1]
+        split.each_with_index do |lines, index|
+          chunks << Chunk.new(self, chunks_meta[index], cleanup(lines))
         end
       end
     end
@@ -88,6 +87,10 @@ module PrettyDiff
 
     def enforce_encoding(text)
       Encoding.enforce(out_encoding, text)
+    end
+
+    def cleanup(line)
+      line[1..-1]
     end
 
   end

--- a/lib/pretty_diff/line_numbers.rb
+++ b/lib/pretty_diff/line_numbers.rb
@@ -37,7 +37,7 @@ module PrettyDiff
     end
 
     def right_starts_at
-      scan_meta(/\+(\d+),\d+ @@$/).to_i
+      scan_meta(/\+(\d+),\d+ @@/).to_i
     end
 
     def increase_left

--- a/test/basic_generator_test.rb
+++ b/test/basic_generator_test.rb
@@ -1,11 +1,10 @@
-require File.join(File.dirname(__FILE__), 'helper')
+require 'helper'
 
 class BasicGeneratorTest < MiniTest::Unit::TestCase
 
   def test_generated_html
     diff = new_diff(fixture('first.diff'), :generator => PrettyDiff::BasicGenerator)
     assert_equal fixture('first.diff.html'), diff.to_html
-
   end
 
   def test_more_generated_html
@@ -13,4 +12,8 @@ class BasicGeneratorTest < MiniTest::Unit::TestCase
     assert_equal fixture('text.diff.html'), diff.to_html
   end
 
+  def test_another_generated_html
+    diff = new_diff(fixture('csharp.diff'), :generator => PrettyDiff::BasicGenerator)
+    assert_equal fixture('csharp.diff.html'), diff.to_html
+  end
 end

--- a/test/fixtures/csharp.diff
+++ b/test/fixtures/csharp.diff
@@ -1,0 +1,12 @@
+diff --git a/src/Data/ServiceMail/ServiceEmailBase.cs b/src/Data/ServiceMail/ServiceEmailBase.cs
+index a93dedb..5cb1240 100644
+--- a/src/Data/ServiceMail/ServiceEmailBase.cs
++++ b/src/Data/ServiceMail/ServiceEmailBase.cs
+@@ -21,7 +21,7 @@ namespace PostalService.Data.ServiceMail
+         public abstract string GenerateSubject();
+         public abstract string GenerateTextBody();
+         public abstract string GenerateHtmlBody();
+-        public abstract string GenerateTag();
++        public abstract string GenerateTag(); change on line 24
+ 
+         private readonly SystemSettings _systemSettings;

--- a/test/fixtures/csharp.diff.html
+++ b/test/fixtures/csharp.diff.html
@@ -1,0 +1,19 @@
+<div class="diff"><div class="diff-chunk"><div class="diff-line-nums"><pre>21
+22
+23
+24
+&nbsp;
+25
+26</pre></div><div class="diff-line-nums"><pre>21
+22
+23
+&nbsp;
+24
+25
+26</pre></div><div class="diff-code"><pre>         public abstract string GenerateSubject();
+         public abstract string GenerateTextBody();
+         public abstract string GenerateHtmlBody();
+<span class="diff-line-del">-        public abstract string GenerateTag();</span>
+<span class="diff-line-add">+        public abstract string GenerateTag(); change on line 24</span>
+ 
+         private readonly SystemSettings _systemSettings;</pre></div></div></div>

--- a/test/fixtures/text.diff.html
+++ b/test/fixtures/text.diff.html
@@ -2,14 +2,11 @@
 4
 5
 6
-7
 &nbsp;</pre></div><div class="diff-line-nums"><pre>3
 4
 5
-6
 &nbsp;
-7</pre></div><div class="diff-code"><pre> line2
- line3
+6</pre></div><div class="diff-code"><pre> line3
  line4 new
  line5
 <span class="diff-line-del">-line6 change seleniunm</span>


### PR DESCRIPTION
The HTML generated is incorrect when the diff chunk contained characters after the last pair of `@@`.

For example, given the diff:

``` diff
@@ -23,11 +23,11 @@ OSFileEntry::OSFileEntry(const Polycode::String& fullPath, int type) {
   std::vector<String> parts = fullPath.split("/");

   if(parts.size() > 0) {
-    String path = parts[0];
+    String path = parts[0];  // this is line 26

     if(parts.size() > 1) {
       for(int i=1; i < parts.size()-1; i++) {
-        path += "/" + parts[i];
+        path += "/" + parts[i]; // this is line 30
       }
       init(path, parts[parts.size()-1], type);
     }
```

It would count the following as line 23:

``` cpp
 OSFileEntry::OSFileEntry(const Polycode::String& fullPath, int type) {
```

But line 23 actually starts after the chunk's line. Regardless of code being on the same line as the diff chunk. So the correct line 23 is:

``` cpp
std::vector<String> parts = fullPath.split("/");
```

This patch fixes this issue.
