### PR TITLE
Fixed line number generator

### DIFF
--- a/lib/pretty_diff/line_numbers.rb
+++ b/lib/pretty_diff/line_numbers.rb
@@ -33,11 +33,11 @@ module PrettyDiff
     end
 
     def left_starts_at
-      scan_meta(/^@@ -(\d+),/).to_i
+      scan_meta(/^@@ -(\d+)/).to_i
     end
 
     def right_starts_at
-      scan_meta(/\+(\d+),\d+ @@/).to_i
+      scan_meta(/\+(\d+)(?:,\d+)? @@/).to_i
     end
 
     def increase_left

--- a/test/basic_generator_test.rb
+++ b/test/basic_generator_test.rb
@@ -21,4 +21,9 @@ class BasicGeneratorTest < MiniTest::Unit::TestCase
     diff = new_diff(fixture('blank.diff'), :generator => PrettyDiff::BasicGenerator)
     assert_equal fixture('blank.diff.html'), diff.to_html
   end
+
+  def test_generate_html_for_single_line_diffs
+    diff = new_diff(fixture('single_line.diff'), :generator => PrettyDiff::BasicGenerator)
+    assert_equal fixture('single_line.diff.html'), diff.to_html
+  end
 end

--- a/test/fixtures/single_line.diff
+++ b/test/fixtures/single_line.diff
@@ -1,0 +1,7 @@
+diff --git a/html/exp2.txt b/html/exp2.txt
+index a78cb18..e2274ae 100644
+--- a/html/exp2.txt
++++ b/html/exp2.txt
+@@ -1 +1 @@
+-assome example text
++asassome example text

--- a/test/fixtures/single_line.diff.html
+++ b/test/fixtures/single_line.diff.html
@@ -1,0 +1,4 @@
+<div class="diff"><div class="diff-chunk"><div class="diff-line-nums"><pre>1
+&nbsp;</pre></div><div class="diff-line-nums"><pre>&nbsp;
+1</pre></div><div class="diff-code"><pre><span class="diff-line-del">-assome example text</span>
+<span class="diff-line-add">+asassome example text</span></pre></div></div></div>

--- a/test/line_numbers_test.rb
+++ b/test/line_numbers_test.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'helper')
+require 'helper'
 
 class LineNumbersTest < MiniTest::Unit::TestCase
 
@@ -17,4 +17,9 @@ class LineNumbersTest < MiniTest::Unit::TestCase
       @numbers.right_column
   end
 
+  def test_line_numbers
+    @diff = new_diff fixture('single_line.diff')
+    assert_equal [1, nil], @diff.chunks.last.line_numbers.left_column
+    assert_equal [nil, 1], @diff.chunks.last.line_numbers.right_column
+  end
 end


### PR DESCRIPTION
Updated the line number chunk regex to match an edge case. Added test cases to confirm the fix.

Here's an example:

``` diff
diff --git a/html/exp2.txt b/html/exp2.txt
index a78cb18..e2274ae 100644
--- a/html/exp2.txt
+++ b/html/exp2.txt
@@ -1 +1 @@
-assome example text
+asassome example text
```
