### PR TITLE
Fix validating generator

### DIFF
--- a/lib/pretty_diff/diff.rb
+++ b/lib/pretty_diff/diff.rb
@@ -79,11 +79,11 @@ module PrettyDiff
       end
     end
 
-    def valid_generator?(gen)
-      gen != nil &&
-      gen.kind_of?(Class) &&
-      gen.superclass == AbstractGenerator &&
-      gen.instance_methods.include?(:generate)
+    def valid_generator?(generator)
+      !generator.nil? &&
+      generator.kind_of?(Class) &&
+      generator.ancestors.include?(PrettyDiff::AbstractGenerator) &&
+      generator.instance_methods.include?(:generate)
     end
 
     def enforce_encoding(text)

--- a/test/diff_test.rb
+++ b/test/diff_test.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), 'helper')
 
 class DiffTest < MiniTest::Unit::TestCase
   class SuperGenerator < PrettyDiff::AbstractGenerator; def generate;end; end
+  class UberGenerator < SuperGenerator; end
 
   class NotAGenerator; end
 
@@ -38,6 +39,8 @@ class DiffTest < MiniTest::Unit::TestCase
     assert_raises PrettyDiff::InvalidGenerator do
       new_diff('bla', :generator => NotAGenerator)
     end
+
+    assert new_diff('bla', :generator => UberGenerator)
   end
 
   def test_default_encoding


### PR DESCRIPTION
``` ruby
def valid_generator?(generator)
  # other conditions
  gen.superclass == AbstractGenerator
end
```

The above line only works for classes that directly inherit from `AbstractGenerator`. This patch allows any subclass of `AbstractGenerator` to be validated as a generator.
